### PR TITLE
Function-like proc macros in expressions for 1.45

### DIFF
--- a/data/1.45/expr_proc_macro.md
+++ b/data/1.45/expr_proc_macro.md
@@ -1,0 +1,6 @@
++++
+title = "function-like procedural macros in expression, pattern and statement position"
+impl_pr_id = 68717
+tracking_issue_id = 54727
+stabilization_pr_id = 68717
++++

--- a/data/1.45/expr_proc_macro.md
+++ b/data/1.45/expr_proc_macro.md
@@ -1,6 +1,6 @@
 +++
 title = "function-like procedural macros in expression, pattern and statement position"
-impl_pr_id = 68717
+flag = "proc_macro_hygiene"
 tracking_issue_id = 54727
 stabilization_pr_id = 68717
 +++


### PR DESCRIPTION
Function-like proc-macros in expression, pattern and statement attributes were added in version 1.45.

[Release notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1450-2020-07-16)
