### PR TITLE
Add release date and release notes to version page

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,10 @@ struct VersionData {
     /// The channel (stable / beta / nightly)
     #[serde(default)]
     channel: Channel,
+    /// Release date, in format "yyyy-mm-dd"
+    release_date: String,
+    /// Release notes (https://github.com/rust-lang/rust/blob/master/RELEASES.md#{anchor})
+    release_notes: Option<String>,
     /// Blog post path (https://blog.rust-lang.org/{path})
     blog_post_path: Option<String>,
     /// GitHub milestone id (https://github.com/rust-lang/rust/milestone/{id})
@@ -235,6 +239,8 @@ fn generate_output(feature_toml: Data) -> TokenStream {
         let v_idx = v.version.map(|d| {
             let number = &d.number;
             let channel = Ident::new(&format!("{:?}", d.channel), Span::call_site());
+            let release_date = &d.release_date;
+            let release_notes = option_literal(&d.release_notes);
             let blog_post_path = option_literal(&d.blog_post_path);
             let gh_milestone_id = option_literal(&d.gh_milestone_id);
 
@@ -242,6 +248,8 @@ fn generate_output(feature_toml: Data) -> TokenStream {
                 VersionData {
                     number: #number,
                     channel: Channel::#channel,
+                    release_date: #release_date,
+                    release_notes: #release_notes,
                     blog_post_path: #blog_post_path,
                     gh_milestone_id: #gh_milestone_id,
                 }

--- a/data/1.0/version.toml
+++ b/data/1.0/version.toml
@@ -1,3 +1,5 @@
 number = "1.0"
+release_date = "2015-05-15"
+release_notes = "version-100-2015-05-15"
 gh_milestone_id = 20
 blog_post_path = "2015/05/15/Rust-1.0.html"

--- a/data/1.1/version.toml
+++ b/data/1.1/version.toml
@@ -1,2 +1,4 @@
 number = "1.1"
+release_date = "2015-06-25"
+release_notes = "version-110-2015-06-25"
 blog_post_path = "2015/06/25/Rust-1.1.html"

--- a/data/1.10/version.toml
+++ b/data/1.10/version.toml
@@ -1,2 +1,4 @@
 number = "1.10"
+release_date = "2016-07-07"
+release_notes = "version-1100-2016-07-07"
 blog_post_path = "2016/07/07/Rust-1.10.html"

--- a/data/1.11/version.toml
+++ b/data/1.11/version.toml
@@ -1,2 +1,4 @@
 number = "1.11"
+release_date = "2016-08-18"
+release_notes = "version-1110-2016-08-18"
 blog_post_path = "2016/08/18/Rust-1.11.html"

--- a/data/1.12/version.toml
+++ b/data/1.12/version.toml
@@ -1,2 +1,4 @@
 number = "1.12"
+release_date = "2016-09-29"
+release_notes = "version-1120-2016-09-29"
 blog_post_path = "2016/09/29/Rust-1.12.html"

--- a/data/1.13/version.toml
+++ b/data/1.13/version.toml
@@ -1,2 +1,4 @@
 number = "1.13"
+release_date = "2016-11-10"
+release_notes = "version-1130-2016-11-10"
 blog_post_path = "2016/11/10/Rust-1.13.html"

--- a/data/1.14/version.toml
+++ b/data/1.14/version.toml
@@ -1,2 +1,4 @@
 number = "1.14"
+release_date = "2016-12-22"
+release_notes = "version-1140-2016-12-22"
 blog_post_path = "2016/12/22/Rust-1.14.html"

--- a/data/1.15/version.toml
+++ b/data/1.15/version.toml
@@ -1,2 +1,4 @@
 number = "1.15"
+release_date = "2017-02-02"
+release_notes = "version-1150-2017-02-02"
 blog_post_path = "2017/02/02/Rust-1.15.html"

--- a/data/1.16/version.toml
+++ b/data/1.16/version.toml
@@ -1,3 +1,5 @@
 number = "1.16"
+release_date = "2017-03-16"
+release_notes = "version-1160-2017-03-16"
 gh_milestone_id = 33
 blog_post_path = "2017/03/16/Rust-1.16.html"

--- a/data/1.17/version.toml
+++ b/data/1.17/version.toml
@@ -1,3 +1,5 @@
 number = "1.17"
+release_date = "2017-04-27"
+release_notes = "version-1170-2017-04-27"
 gh_milestone_id = 34
 blog_post_path = "2017/04/27/Rust-1.17.html"

--- a/data/1.18/version.toml
+++ b/data/1.18/version.toml
@@ -1,3 +1,5 @@
 number = "1.18"
+release_date = "2017-06-08"
+release_notes = "version-1180-2017-06-08"
 gh_milestone_id = 35
 blog_post_path = "2017/06/08/Rust-1.18.html"

--- a/data/1.19/version.toml
+++ b/data/1.19/version.toml
@@ -1,3 +1,5 @@
 number = "1.19"
+release_date = "2017-07-20"
+release_notes = "version-1190-2017-07-20"
 gh_milestone_id = 36
 blog_post_path = "2017/07/20/Rust-1.19.html"

--- a/data/1.2/version.toml
+++ b/data/1.2/version.toml
@@ -1,2 +1,4 @@
 number = "1.2"
+release_date = "2015-08-07"
+release_notes = "version-120-2015-08-07"
 blog_post_path = "2015/08/06/Rust-1.2.html"

--- a/data/1.20/version.toml
+++ b/data/1.20/version.toml
@@ -1,3 +1,5 @@
 number = "1.20"
+release_date = "2017-08-31"
+release_notes = "version-1200-2017-08-31"
 gh_milestone_id = 37
 blog_post_path = "2017/08/31/Rust-1.20.html"

--- a/data/1.21/version.toml
+++ b/data/1.21/version.toml
@@ -1,3 +1,5 @@
 number = "1.21"
+release_date = "2017-10-12"
+release_notes = "version-1210-2017-10-12"
 gh_milestone_id = 38
 blog_post_path = "2017/10/12/Rust-1.21.html"

--- a/data/1.22/version.toml
+++ b/data/1.22/version.toml
@@ -1,3 +1,5 @@
 number = "1.22"
+release_date = "2017-11-22"
+release_notes = "version-1220-2017-11-22"
 gh_milestone_id = 39
 blog_post_path = "2017/11/22/Rust-1.22.html"

--- a/data/1.23/version.toml
+++ b/data/1.23/version.toml
@@ -1,3 +1,5 @@
 number = "1.23"
+release_date = "2018-01-04"
+release_notes = "version-1230-2018-01-04"
 gh_milestone_id = 40
 blog_post_path = "2018/01/04/Rust-1.23.html"

--- a/data/1.24/version.toml
+++ b/data/1.24/version.toml
@@ -1,3 +1,5 @@
 number = "1.24"
+release_date = "2018-02-15"
+release_notes = "version-1240-2018-02-15"
 gh_milestone_id = 41
 blog_post_path = "2018/02/15/Rust-1.24.html"

--- a/data/1.25/version.toml
+++ b/data/1.25/version.toml
@@ -1,3 +1,5 @@
 number = "1.25"
+release_date = "2018-03-29"
+release_notes = "version-1250-2018-03-29"
 gh_milestone_id = 44
 blog_post_path = "2018/03/29/Rust-1.25.html"

--- a/data/1.26/version.toml
+++ b/data/1.26/version.toml
@@ -1,3 +1,5 @@
 number = "1.26"
+release_date = "2018-05-10"
+release_notes = "version-1260-2018-05-10"
 gh_milestone_id = 48
 blog_post_path = "2018/05/10/Rust-1.26.html"

--- a/data/1.27/version.toml
+++ b/data/1.27/version.toml
@@ -1,3 +1,5 @@
 number = "1.27"
+release_date = "2018-06-21"
+release_notes = "version-1270-2018-06-21"
 gh_milestone_id = 50
 blog_post_path = "2018/06/21/Rust-1.27.html"

--- a/data/1.28/version.toml
+++ b/data/1.28/version.toml
@@ -1,3 +1,5 @@
 number = "1.28"
+release_date = "2018-08-02"
+release_notes = "version-1280-2018-08-02"
 gh_milestone_id = 51
 blog_post_path = "2018/08/02/Rust-1.28.html"

--- a/data/1.29/version.toml
+++ b/data/1.29/version.toml
@@ -1,3 +1,5 @@
 number = "1.29"
+release_date = "2018-09-13"
+release_notes = "version-1290-2018-09-13"
 gh_milestone_id = 53
 blog_post_path = "2018/09/13/Rust-1.29.html"

--- a/data/1.3/version.toml
+++ b/data/1.3/version.toml
@@ -1,2 +1,4 @@
 number = "1.3"
+release_date = "2015-09-17"
+release_notes = "version-130-2015-09-17"
 blog_post_path = "2015/09/17/Rust-1.3.html"

--- a/data/1.30/version.toml
+++ b/data/1.30/version.toml
@@ -1,3 +1,5 @@
 number = "1.30"
+release_date = "2018-10-25"
+release_notes = "version-1300-2018-10-25"
 gh_milestone_id = 57
 blog_post_path = "2018/10/25/Rust-1.30.0.html"

--- a/data/1.31/version.toml
+++ b/data/1.31/version.toml
@@ -1,3 +1,5 @@
 number = "1.31"
+release_date = "2018-12-06"
+release_notes = "version-1310-2018-12-06"
 gh_milestone_id = 58
 blog_post_path = "2018/12/06/Rust-1.31-and-rust-2018.html"

--- a/data/1.32/version.toml
+++ b/data/1.32/version.toml
@@ -1,3 +1,5 @@
 number = "1.32"
+release_date = "2019-01-17"
+release_notes = "version-1320-2019-01-17"
 gh_milestone_id = 63
 blog_post_path = "2019/01/17/Rust-1.32.0.html"

--- a/data/1.33/version.toml
+++ b/data/1.33/version.toml
@@ -1,3 +1,5 @@
 number = "1.33"
+release_date = "2019-02-28"
+release_notes = "version-1330-2019-02-28"
 gh_milestone_id = 59
 blog_post_path = "2019/02/28/Rust-1.33.0.html"

--- a/data/1.34/version.toml
+++ b/data/1.34/version.toml
@@ -1,3 +1,5 @@
 number = "1.34"
+release_date = "2019-04-11"
+release_notes = "version-1340-2019-04-11"
 gh_milestone_id = 60
 blog_post_path = "2019/04/11/Rust-1.34.0.html"

--- a/data/1.35/version.toml
+++ b/data/1.35/version.toml
@@ -1,3 +1,5 @@
 number = "1.35"
+release_date = "2019-05-23"
+release_notes = "version-1350-2019-05-23"
 gh_milestone_id = 61
 blog_post_path = "2019/05/23/Rust-1.35.0.html"

--- a/data/1.36/version.toml
+++ b/data/1.36/version.toml
@@ -1,3 +1,5 @@
 number = "1.36"
+release_date = "2019-07-04"
+release_notes = "version-1360-2019-07-04"
 gh_milestone_id = 62
 blog_post_path = "2019/07/04/Rust-1.36.0.html"

--- a/data/1.37/version.toml
+++ b/data/1.37/version.toml
@@ -1,3 +1,5 @@
 number = "1.37"
+release_date = "2019-08-15"
+release_notes = "version-1370-2019-08-15"
 gh_milestone_id = 64
 blog_post_path = "2019/08/15/Rust-1.37.0.html"

--- a/data/1.38/version.toml
+++ b/data/1.38/version.toml
@@ -1,3 +1,5 @@
 number = "1.38"
+release_date = "2019-09-26"
+release_notes = "version-1380-2019-09-26"
 gh_milestone_id = 65
 blog_post_path = "2019/09/26/Rust-1.38.0.html"

--- a/data/1.39/version.toml
+++ b/data/1.39/version.toml
@@ -1,3 +1,5 @@
 number = "1.39"
+release_date = "2019-11-07"
+release_notes = "version-1390-2019-11-07"
 gh_milestone_id = 66
 blog_post_path = "2019/11/07/Rust-1.39.0.html"

--- a/data/1.4/version.toml
+++ b/data/1.4/version.toml
@@ -1,3 +1,5 @@
 number = "1.4"
+release_date = "2015-10-29"
+release_notes = "version-140-2015-10-29"
 gh_milestone_id = 26
 blog_post_path = "2015/10/29/Rust-1.4.html"

--- a/data/1.40/version.toml
+++ b/data/1.40/version.toml
@@ -1,3 +1,5 @@
 number = "1.40"
+release_date = "2019-12-19"
+release_notes = "version-1400-2019-12-19"
 gh_milestone_id = 67
 blog_post_path = "2019/12/19/Rust-1.40.0.html"

--- a/data/1.41/version.toml
+++ b/data/1.41/version.toml
@@ -1,3 +1,5 @@
 number = "1.41"
+release_date = "2020-01-30"
+release_notes = "version-1410-2020-01-30"
 gh_milestone_id = 68
 blog_post_path = "2020/01/30/Rust-1.41.0.html"

--- a/data/1.42/version.toml
+++ b/data/1.42/version.toml
@@ -1,3 +1,5 @@
 number = "1.42"
+release_date = "2020-03-12"
+release_notes = "version-1420-2020-03-12"
 gh_milestone_id = 69
 blog_post_path = "2020/03/12/Rust-1.42.html"

--- a/data/1.43/version.toml
+++ b/data/1.43/version.toml
@@ -1,3 +1,5 @@
 number = "1.43"
+release_date = "2020-04-23"
+release_notes = "version-1430-2020-04-23"
 gh_milestone_id = 70
 blog_post_path = "2020/04/23/Rust-1.43.0.html"

--- a/data/1.44/version.toml
+++ b/data/1.44/version.toml
@@ -1,3 +1,5 @@
 number = "1.44"
+release_date = "2020-06-04"
+release_notes = "version-1440-2020-06-04"
 gh_milestone_id = 71
 blog_post_path = "2020/06/04/Rust-1.44.0.html"

--- a/data/1.45/version.toml
+++ b/data/1.45/version.toml
@@ -1,3 +1,5 @@
 number = "1.45"
+release_date = "2020-07-16"
+release_notes = "version-1450-2020-07-16"
 gh_milestone_id = 72
 blog_post_path = "2020/07/16/Rust-1.45.0.html"

--- a/data/1.46/version.toml
+++ b/data/1.46/version.toml
@@ -1,3 +1,4 @@
 number = "1.46"
+release_date = "2020-08-27"
 channel = "beta"
 gh_milestone_id = 73

--- a/data/1.47/version.toml
+++ b/data/1.47/version.toml
@@ -1,3 +1,4 @@
 number = "1.47"
+release_date = "2020-10-08"
 channel = "nightly"
 gh_milestone_id = 74

--- a/data/1.5/version.toml
+++ b/data/1.5/version.toml
@@ -1,3 +1,5 @@
 number = "1.5"
+release_date = "2015-12-10"
+release_notes = "version-150-2015-12-10"
 gh_milestone_id = 27
 blog_post_path = "2015/12/10/Rust-1.5.html"

--- a/data/1.6/version.toml
+++ b/data/1.6/version.toml
@@ -1,3 +1,5 @@
 number = "1.6"
+release_date = "2016-01-21"
+release_notes = "version-160-2016-01-21"
 gh_milestone_id = 28
 blog_post_path = "2016/01/21/Rust-1.6.html"

--- a/data/1.7/version.toml
+++ b/data/1.7/version.toml
@@ -1,2 +1,4 @@
 number = "1.7"
+release_date = "2016-03-03"
+release_notes = "version-170-2016-03-03"
 blog_post_path = "2016/03/02/Rust-1.7.html"

--- a/data/1.8/version.toml
+++ b/data/1.8/version.toml
@@ -1,2 +1,4 @@
 number = "1.8"
+release_date = "2016-04-14"
+release_notes = "version-180-2016-04-14"
 blog_post_path = "2016/04/14/Rust-1.8.html"

--- a/data/1.9/version.toml
+++ b/data/1.9/version.toml
@@ -1,2 +1,4 @@
 number = "1.9"
+release_date = "2016-05-26"
+release_notes = "version-190-2016-05-26"
 blog_post_path = "2016/05/26/Rust-1.9.html"

--- a/src/components/version_page.rs
+++ b/src/components/version_page.rs
@@ -54,7 +54,7 @@ impl Component for VersionPage {
                     <h3 class="title">{"Rust "}{v.number}</h3>
                     <div class="info">
                         <span>{"Release date:"}</span>
-                        <span>{v.release_date}</span>
+                        <time datetime={v.release_date}>{v.release_date}</time>
                     </div>
                     <ul class="links">
                         {maybe_blog_link}

--- a/src/components/version_page.rs
+++ b/src/components/version_page.rs
@@ -36,6 +36,11 @@ impl Component for VersionPage {
 
         let maybe_blog_link =
             maybe_link("Blog post", "https://blog.rust-lang.org/", v.blog_post_path);
+        let maybe_release_notes = maybe_link(
+            "Release notes",
+            "https://github.com/rust-lang/rust/blob/master/RELEASES.md#",
+            v.release_notes,
+        );
         let maybe_gh_milestone_link = maybe_link(
             "GitHub milestone",
             "https://github.com/rust-lang/rust/milestone/",
@@ -47,8 +52,13 @@ impl Component for VersionPage {
                 {back_button()}
                 <div class="box">
                     <h3 class="title">{"Rust "}{v.number}</h3>
+                    <div class="info">
+                        <span>{"Release date:"}</span>
+                        <span>{v.release_date}</span>
+                    </div>
                     <ul class="links">
                         {maybe_blog_link}
+                        {maybe_release_notes}
                         {maybe_gh_milestone_link}
                     </ul>
                 </div>

--- a/src/data.rs
+++ b/src/data.rs
@@ -39,6 +39,10 @@ pub struct VersionData {
     pub number: &'static str,
     /// The channel (stable / beta / nightly)
     pub channel: Channel,
+    /// Release date, in format "yyyy-mm-dd"
+    pub release_date: &'static str,
+    /// Release notes (https://github.com/rust-lang/rust/blob/master/RELEASES.md#{anchor})
+    pub release_notes: Option<&'static str>,
     /// GitHub milestone id (https://github.com/rust-lang/rust/milestone/{id})
     pub gh_milestone_id: Option<u64>,
     /// Blog post path (https://blog.rust-lang.org/{path})


### PR DESCRIPTION
I think pages for Rustc versions are too empty, so it would be great to populate them a little.
