### PR TITLE
write out data as json file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
+ "serde_json",
  "tera",
  "toml",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ features = [
 anyhow = "1.0.31"
 proc-macro2 = "1.0.18"
 serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1"
 tera = { version = "1.3.1", default-features = false }
 toml = "0.5.6"
 quote = "1.0.7"


### PR DESCRIPTION
I'd quite like to build a simple utility for Alfred (similar to my workflow for caniuse.com, https://github.com/robjtede/alfred-caniuse) and think that a JSON accessible version of the data would be the best approach.

Sample output: https://pastebin.com/Ac5gakPA

Chosen method fits into apparent deploy script of `cp public/* srv/` making the JSON file accessible from https://caniuse.rs/features.json I think.