### PR TITLE
Chore(x.py): move `sys.exit` outside `usage`

### DIFF
--- a/x.py
+++ b/x.py
@@ -36,6 +36,7 @@ def main():
         deploy()
     else:
         usage()
+        sys.exit(1)
 
 
 def run(*args):


### PR DESCRIPTION
Hello there! This PR slightly changes the setup script by moving `sys.exit` outside of the `usage` function. This is so that not every invocation of `usage` is considered to be an erroneous termination.

Previously, exit code 1 is yielded when (1) `x.py` is invoked on its own without any arguments and when (2) `x.py` parses an unknown subcommand. Now, the former case is eliminated so that `x.py` (without any arguments) is considered to be normal termination (i.e., exit code 0). Semantically, this just implies that `x.py` without arguments is still "correct usage" as an explicit help command.

Also, while I was there, I removed some doubled newlines in the script. Since this change is purely stylistic, I would be glad to revert them if you so wish.

> _P.S. If you don't mind, it would be great if this PR was [opted into Hacktoberfest](https://hacktoberfest.digitalocean.com/resources/maintainers). Adding the `hacktoberfest-accepted` label to this PR should be sufficient. That is all. Thanks! 🎉_