### PR TITLE
Add data for nonzero_is_power_of_two

### DIFF
--- a/data/unstable/nonzero_is_power_of_two.md
+++ b/data/unstable/nonzero_is_power_of_two.md
@@ -1,5 +1,5 @@
 +++
-title = "NonZeroUn::is_power_of_two"
+title = "`NonZero*::is_power_of_two`"
 flag = "nonzero_is_power_of_two"
 impl_pr_id = 81107
 tracking_issue_id = 81106


### PR DESCRIPTION
Add data for nonzero_is_power_of_two, which defines `is_power_of_two` on nonzero unsigned integer types.

Decisions I made that I'm not totally sure about (but would be happy to fix in this PR):
1. Put this data under `unstable`. #16 has this listed as "stable", but usage still requires nightly Rust and `#![feature]`.
2. Leave `doc_path` empty. There _are_ docs for each type (for example, https://doc.rust-lang.org/std/num/struct.NonZeroUsize.html#method.is_power_of_two), but picking just one didn't seem right. The most similar feature (`data/1.40/const_is_power_of_two.md`) also doesn't set a `doc_path`.