### PR TITLE
Add data for duration_checked_float

### DIFF
--- a/data/unstable/duration_checked_float.md
+++ b/data/unstable/duration_checked_float.md
@@ -1,0 +1,10 @@
++++
+title = "`Duration::try_from_secs_*`"
+flag = "duration_checked_float"
+impl_pr_id = 82179
+tracking_issue_id = 83400
+items = [
+    "Duration::try_from_secs_f32",
+    "Duration::try_from_secs_f64",
+]
++++


### PR DESCRIPTION
Add data for `duration_checked_float`, which defines `Duration::try_from_secs_{f32,f64}`.

#16 lists this one as stable, but it's still behind a feature flag.
