### PR TITLE
Add data for std_collections_from_array

### DIFF
--- a/data/1.56/std_collections_from_array.md
+++ b/data/1.56/std_collections_from_array.md
@@ -3,12 +3,12 @@ title = "`From<[T; N]>` implementation for collections"
 flag = "std_collections_from_array"
 impl_pr_id = 84111
 items = [
-    "BinaryHeap::from",
-    "BTreeMap::from",
-    "BTreeSet::from",
-    "HashMap::from",
-    "HashSet::from",
-    "LinkedList::from",
-    "VecDeque::from",
+    "impl From<T; N> for BinaryHeap<T>",
+    "impl From<T; N> for BTreeMap<T>",
+    "impl From<T; N> for BTreeSet<T>",
+    "impl From<T; N> for HashMap<T>",
+    "impl From<T; N> for HashSet<T>",
+    "impl From<T; N> for LinkedList<T>",
+    "impl From<T; N> for VecDeque<T>",
 ]
 +++


### PR DESCRIPTION
This adds data for `std_collections_from_array` which defines `C::from(array)` for standard collections.

I can't decide whether it's better to add these as a combined file with `items` (like `shrink_to`) or split into one-file-per-function (like `into_keys` and `into_values`). I'm still too new to Rust to know how people will want to search for these features. This is the combined version, but I've got the split version in an easily-available other branch if you'd prefer that one.
