### PR TITLE
Add feature extend_for_tuple

### DIFF
--- a/data/1.56/extend_for_tuple.md
+++ b/data/1.56/extend_for_tuple.md
@@ -1,0 +1,8 @@
++++
+title = "`Extend<A, B>` implementation for tuples"
+flag = "extend_for_tuple"
+impl_pr_id = 85835
+items = [
+    "impl Extend<A, B> for (Extend<A>, Extend<B>)",
+]
++++

--- a/data/1.56/extend_for_tuple.md
+++ b/data/1.56/extend_for_tuple.md
@@ -1,8 +1,5 @@
 +++
-title = "`Extend<A, B>` implementation for tuples"
+title = "`Extend<A, B>` implementation for `(Extend<A>, Extend<B>)`"
 flag = "extend_for_tuple"
 impl_pr_id = 85835
-items = [
-    "impl Extend<A, B> for (Extend<A>, Extend<B>)",
-]
 +++


### PR DESCRIPTION
Add data for `extend_for_tuple`, which allows extending a tuple of collections that also implement `Extend`.
