### PR TITLE
Add `doc_path`s to 1.56 and 1.57 features

### DIFF
--- a/data/1.53/non_ascii_idents.toml
+++ b/data/1.53/non_ascii_idents.toml
@@ -2,4 +2,4 @@ title = "non-ASCII identifiers"
 flag = "non_ascii_idents"
 tracking_issue_id = 55467
 stabilization_pr_id = 83799
-doc_path = "beta/reference/identifiers.html"
+doc_path = "stable/reference/identifiers.html"

--- a/data/1.56/bufwriter_into_parts.toml
+++ b/data/1.56/bufwriter_into_parts.toml
@@ -3,3 +3,4 @@ flag = "bufwriter_into_parts"
 impl_pr_id = 79705
 tracking_issue_id = 80690
 stabilization_pr_id = 88299
+doc_path = "std/io/struct.BufWriter.html#method.into_parts"

--- a/data/1.56/extend_for_tuple.toml
+++ b/data/1.56/extend_for_tuple.toml
@@ -1,3 +1,4 @@
 title = "`Extend<A, B>` implementation for `(Extend<A>, Extend<B>)`"
 flag = "extend_for_tuple"
 impl_pr_id = 85835
+doc_path = "std/iter/trait.Extend.html#impl-Extend<(A%2C%20B)>"

--- a/data/1.56/io_empty_clone.toml
+++ b/data/1.56/io_empty_clone.toml
@@ -1,2 +1,3 @@
 title = "`Clone` implementation for `io::Empty`"
 impl_pr_id = 86744
+doc_path = "std/io/struct.Empty.html#impl-Clone"

--- a/data/1.56/io_empty_copy.toml
+++ b/data/1.56/io_empty_copy.toml
@@ -1,2 +1,3 @@
 title = "`Copy` implementation for `io::Empty`"
 impl_pr_id = 86744
+doc_path = "std/io/struct.Empty.html#impl-Copy"

--- a/data/1.56/io_empty_default.toml
+++ b/data/1.56/io_empty_default.toml
@@ -1,2 +1,3 @@
 title = "`Default` implementation for `io::Empty`"
 impl_pr_id = 86744
+doc_path = "std/io/struct.Empty.html#impl-Default"

--- a/data/1.56/io_sink_clone.toml
+++ b/data/1.56/io_sink_clone.toml
@@ -1,2 +1,3 @@
 title = "`Clone` implementation for `io::Sink`"
 impl_pr_id = 86744
+doc_path = "std/io/struct.Sink.html#impl-Clone"

--- a/data/1.56/io_sink_copy.toml
+++ b/data/1.56/io_sink_copy.toml
@@ -1,2 +1,3 @@
 title = "`Copy` implementation for `io::Sink`"
 impl_pr_id = 86744
+doc_path = "std/io/struct.Sink.html#impl-Copy"

--- a/data/1.56/io_sink_default.toml
+++ b/data/1.56/io_sink_default.toml
@@ -1,2 +1,3 @@
 title = "`Default` implementation for `io::Sink`"
 impl_pr_id = 86744
+doc_path = "std/io/struct.Sink.html#impl-Default"

--- a/data/1.56/shrink_to.toml
+++ b/data/1.56/shrink_to.toml
@@ -13,3 +13,4 @@ items = [
     "Vec::shrink_to",
     "VecDeque::shrink_to",
 ]
+doc_path = "std/vec/struct.Vec.html#method.shrink_to"

--- a/data/1.56/std_collections_from_array.toml
+++ b/data/1.56/std_collections_from_array.toml
@@ -10,3 +10,4 @@ items = [
     "impl From<T; N> for LinkedList<T>",
     "impl From<T; N> for VecDeque<T>",
 ]
+doc_path = "std/collections/struct.VecDeque.html#impl-From<[T%3B%20N]>"

--- a/data/1.56/unix_chroot.toml
+++ b/data/1.56/unix_chroot.toml
@@ -3,3 +3,4 @@ flag = "unix_chroot"
 impl_pr_id = 84716
 tracking_issue_id = 84715
 stabilization_pr_id = 88177
+doc_path = "std/os/unix/fs/fn.chroot.html"

--- a/data/1.57/hashmap_try_reserve.toml
+++ b/data/1.57/hashmap_try_reserve.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/collections/struct.HashMap.html#method.try_reserve"

--- a/data/1.57/hashmap_try_reserve_exact.toml
+++ b/data/1.57/hashmap_try_reserve_exact.toml
@@ -1,5 +1,0 @@
-title = "`HashMap::try_reserve_exact`"
-flag = "try_reserve"
-impl_pr_id = 48648
-tracking_issue_id = 48043
-stabilization_pr_id = 87993

--- a/data/1.57/hashset_try_reserve.toml
+++ b/data/1.57/hashset_try_reserve.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/collections/struct.HashSet.html#method.try_reserve"

--- a/data/1.57/hashset_try_reserve_exact.toml
+++ b/data/1.57/hashset_try_reserve_exact.toml
@@ -1,5 +1,0 @@
-title = "`HashSet::try_reserve_exact`"
-flag = "try_reserve"
-impl_pr_id = 48648
-tracking_issue_id = 48043
-stabilization_pr_id = 87993

--- a/data/1.57/proc_macro_is_available.toml
+++ b/data/1.57/proc_macro_is_available.toml
@@ -3,3 +3,4 @@ flag = "proc_macro_is_available"
 impl_pr_id = 71400
 tracking_issue_id = 71436
 stabilization_pr_id = 89735
+doc_path = "proc_macro/fn.is_available.html"

--- a/data/1.57/string_try_reserve.toml
+++ b/data/1.57/string_try_reserve.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/string/struct.String.html#method.try_reserve"

--- a/data/1.57/string_try_reserve_exact.toml
+++ b/data/1.57/string_try_reserve_exact.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/string/struct.String.html#method.try_reserve_exact"

--- a/data/1.57/vec_try_reserve.toml
+++ b/data/1.57/vec_try_reserve.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/vec/struct.Vec.html#method.try_reserve"

--- a/data/1.57/vec_try_reserve_exact.toml
+++ b/data/1.57/vec_try_reserve_exact.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/vec/struct.Vec.html#method.try_reserve_exact"

--- a/data/1.57/vecdeque_try_reserve.toml
+++ b/data/1.57/vecdeque_try_reserve.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/collections/struct.VecDeque.html#method.try_reserve"

--- a/data/1.57/vecdeque_try_reserve_exact.toml
+++ b/data/1.57/vecdeque_try_reserve_exact.toml
@@ -3,3 +3,4 @@ flag = "try_reserve"
 impl_pr_id = 48648
 tracking_issue_id = 48043
 stabilization_pr_id = 87993
+doc_path = "std/collections/struct.VecDeque.html#method.try_reserve_exact"


### PR DESCRIPTION
Also removes `try_reserve_exact` features for HashMap and HashSet which will not exist [according to the tracking issue](https://github.com/rust-lang/rust/issues/48043).