### PR TITLE
Remove versions[_].number from features.json

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,7 @@ struct Data {
 #[derive(Deserialize, Serialize)]
 struct VersionData {
     /// Rust version number, e.g. "1.0.0"
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     number: String,
     /// The channel (stable / beta / nightly)
     #[serde(default)]


### PR DESCRIPTION
Before:

```json
    "1.56": {
      "blog_post_path": "2021/10/21/Rust-1.56.0.html",
      "channel": "stable",
      "gh_milestone_id": 85,
      "number": "1.56",
      "release_date": "2021-10-21",
      "release_notes": "version-1560-2021-10-21"
    },
```

After:

```json
    "1.56": {
      "blog_post_path": "2021/10/21/Rust-1.56.0.html",
      "channel": "stable",
      "gh_milestone_id": 85,
      "release_date": "2021-10-21",
      "release_notes": "version-1560-2021-10-21"
    },
```

Would this break your project, @robjtede?