### PR TITLE
Add cfg_panic

### DIFF
--- a/data/1.60/cfg_panic.toml
+++ b/data/1.60/cfg_panic.toml
@@ -1,0 +1,4 @@
+title = "`#[cfg(panic = ...)]`"
+impl_pr_id = 74754
+tracking_issue_id = 77443
+stabilization_pr_id = 93658


### PR DESCRIPTION
I didn't find `#[cfg(panic = ...)]` -- hope the data is right, not too sure of all the branches, please verify (I was basing the version on the date it was merged and the lack of "remove this from beta again" backlinks).

Direct link to the referenced PR: https://github.com/rust-lang/rust/pull/74754