### PR TITLE
Stabilization of const_fn_fn_ptr_basics / const_fn_trait_bound / const_impl_trait imminent

### DIFF
--- a/data/unstable/const_fn_fn_ptr_basics.toml
+++ b/data/unstable/const_fn_fn_ptr_basics.toml
@@ -1,0 +1,4 @@
+title = "`const fn` returning function pointers"
+flag = "const_fn_fn_ptr_basics"
+tracking_issue_id = 57563
+stabilization_pr_id = 93827

--- a/data/unstable/const_fn_trait_bound.toml
+++ b/data/unstable/const_fn_trait_bound.toml
@@ -1,0 +1,4 @@
+title = "Trait bounds on generics of a `const fn`"
+flag = "const_fn_trait_bound"
+tracking_issue_id = 93706
+stabilization_pr_id = 93827

--- a/data/unstable/const_impl_trait.toml
+++ b/data/unstable/const_impl_trait.toml
@@ -1,0 +1,4 @@
+title = "`const fn` returning `impl Trait`"
+flag = "const_impl_trait"
+tracking_issue_id = 77463
+stabilization_pr_id = 93827


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/93827 stabilizes a bunch of const-fn related features.

I didn't find implementation PRs for any of them; const_fn_trait_bound even has an explicit "????" in the history section of its tracking PR.

All tracking PRs as per their entries in the Rust unstable book -- for const_fn_fn_ptr_basics that's even just the meta PR but I didn't find any more concrete one, they're all a bit intermingled but at least well distinguished in the features that can soon be dropped.

FCP has completed but the merge is not through yet; once it's closed these can go to the 1.61 data dir (we can also keep this open and I add the move commit before this is merged if you prefer).