### PR TITLE
core::ffi::CStr and alloc::ffi::CString have been stabilized

### DIFF
--- a/data/1.64/alloc_cstr.toml
+++ b/data/1.64/alloc_cstr.toml
@@ -1,0 +1,9 @@
+title = "`CString` in `alloc`"
+flag = "alloc_c_str"
+impl_pr_id = 94079
+tracking_issue_id = 98314
+stabilization_pr_id = 99277
+doc_path = "alloc/ffi/struct.CString.html"
+items = [
+    "alloc::ffi::CString",
+]

--- a/data/1.64/core_cstr.toml
+++ b/data/1.64/core_cstr.toml
@@ -1,0 +1,9 @@
+title = "`CStr` in `core`"
+flag = "core_c_str"
+impl_pr_id = 94079
+tracking_issue_id = 98314
+stabilization_pr_id = 99277
+doc_path = "core/ffi/struct.CStr.html"
+items = [
+    "core::ffi::CStr",
+]


### PR DESCRIPTION
Expressing them in two items as `flag` and `doc_path` are distinct.